### PR TITLE
ThemeDeck #18 | Media not removing when calling player.remove & playlist set to loop

### DIFF
--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -564,6 +564,7 @@ class NativePlayer extends PlatformPlayer {
           [
             PlaylistMode.none,
             PlaylistMode.single,
+            PlaylistMode.loop,
           ].contains(state.playlistMode)) {
         state = state.copyWith(
           // Allow playOrPause /w state.completed code-path to play the playlist again.


### PR DESCRIPTION
https://github.com/isaacy13/ThemeDeck/issues/18
- player.remove: manually update playlist whenever playlist is set to loop