### PR TITLE
ThemeDeck #20 | Disable MPV cleanup each time Flutter window is created

### DIFF
--- a/media_kit_native_event_loop/src/media_kit_native_event_loop.cc
+++ b/media_kit_native_event_loop/src/media_kit_native_event_loop.cc
@@ -148,20 +148,7 @@ void MediaKitEventLoopHandler::Dispose(int64_t handle, bool clean) {
   std::cout << "MediaKitEventLoopHandler::Dispose: " << handle << std::endl;
 }
 
-void MediaKitEventLoopHandler::Initialize() {
-  auto contexts = std::vector<mpv_handle*>();
-
-  mutex_.lock();
-  for (auto& [context, _] : threads_) {
-    contexts.push_back(context);
-  }
-  mutex_.unlock();
-
-  for (auto& context : contexts) {
-    Dispose(reinterpret_cast<int64_t>(context));
-    mpv_command_string(context, "quit");
-  }
-}
+void MediaKitEventLoopHandler::Initialize() {}
 
 bool MediaKitEventLoopHandler::IsRegistered(int64_t handle) {
   std::lock_guard<std::mutex> lock(mutex_);


### PR DESCRIPTION
https://github.com/isaacy13/ThemeDeck/issues/20
- spinning up new flutter windows should not invalidate previous windows