### PR TITLE
ThemeDeck #25 | Crashing when using hardware acceleration on multiple Flutter instances using media_kit

### DIFF
--- a/media_kit_video/windows/angle_surface_manager.cc
+++ b/media_kit_video/windows/angle_surface_manager.cc
@@ -23,7 +23,7 @@
   }
 
 int ANGLESurfaceManager::instance_count_ = 0;
-
+HANDLE ANGLESurfaceManager::mutex_ = nullptr;
 ANGLESurfaceManager::ANGLESurfaceManager(int32_t width, int32_t height)
     : width_(width), height_(height) {
   mutex_ = ::CreateMutex(NULL, FALSE, NULL);

--- a/media_kit_video/windows/angle_surface_manager.h
+++ b/media_kit_video/windows/angle_surface_manager.h
@@ -71,7 +71,7 @@ class ANGLESurfaceManager {
   HANDLE handle_ = nullptr;
 
   // Sync |Draw| & |Read| calls.
-  HANDLE mutex_ = nullptr;
+  static HANDLE mutex_;
   // D3D 11
   ID3D11Device* d3d_11_device_ = nullptr;
   ID3D11DeviceContext* d3d_11_device_context_ = nullptr;


### PR DESCRIPTION
https://github.com/isaacy13/ThemeDeck/issues/25
- fixed issue where using hardware acceleration on multiple Flutter instances using media_kit was causing crashes