### PR TITLE
ThemeDeck #20 | don't do MPV cleanup if sub-window

### DIFF
--- a/media_kit_native_event_loop/src/media_kit_native_event_loop.cc
+++ b/media_kit_native_event_loop/src/media_kit_native_event_loop.cc
@@ -149,6 +149,8 @@ void MediaKitEventLoopHandler::Dispose(int64_t handle, bool clean) {
 }
 
 void MediaKitEventLoopHandler::Initialize(int64_t windowId) {
+  // If |windowId| is non-zero, then return; MPV cleanup should only happen when main window (id=0) is initialized
+  if (windowId) { return; }
   auto contexts = std::vector<mpv_handle*>();
 
   mutex_.lock();


### PR DESCRIPTION
https://github.com/isaacy13/ThemeDeck/issues/20

- sub-windows should not perform MPV cleanup
- main window should perform MPV cleanup on initialization